### PR TITLE
[Packaging] Hotfix Update requirements.py3.Linux.txt

### DIFF
--- a/src/azure-cli/requirements.py3.Linux.txt
+++ b/src/azure-cli/requirements.py3.Linux.txt
@@ -103,6 +103,7 @@ javaproperties==0.5.1
 jmespath==0.9.5
 jsondiff==2.0.0
 knack==0.11.0
+MarkupSafe==2.0.1
 msal-extensions==1.2.0
 msal[broker]==1.32.0
 msrest==0.7.1


### PR DESCRIPTION
Might fix 
```
cannot import name 'soft_unicode' from 'markupsafe'
```
for linux users.

YMMV

See:
- https://github.com/Azure/azure-cli-extensions/issues/5533
- https://github.com/Azure/azure-cli/issues/22797

A similar fix might be added to the other requirements files, but I am not fiddling with those.

**Related command**

**Description**<!--Mandatory-->

```shell
$ az alias list
...
Unable to load extension 'alias: cannot import name 'soft_unicode' from 'markupsafe' (/home/ale/.azure/cliextensions/alias/markupsafe/__init__.py)'. Use --debug for more information.
'alias' is misspelled or not recognized by the system.
```

**Testing Guide**

```shell
$ az extension add --name=alias
$ az alias list
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
